### PR TITLE
Replaced FFMPEG function that no longer exists in the latest distributio...

### DIFF
--- a/Motion/src/Motion/DataSource.cpp
+++ b/Motion/src/Motion/DataSource.cpp
@@ -109,7 +109,7 @@ namespace mt
         }
         if (m_formatcontext)
         {
-            av_close_input_file(m_formatcontext);
+			avformat_close_input(&m_formatcontext);
             m_formatcontext = nullptr;
         }
     }

--- a/Motion/src/Motion/DataSource.cpp
+++ b/Motion/src/Motion/DataSource.cpp
@@ -109,7 +109,7 @@ namespace mt
         }
         if (m_formatcontext)
         {
-			avformat_close_input(&m_formatcontext);
+            avformat_close_input(&m_formatcontext);
             m_formatcontext = nullptr;
         }
     }


### PR DESCRIPTION
The latest distribution release of FFMPEG removed av_close_input_file().  I replaced it with the recommended successor (http://ffmpeg.org/pipermail/ffmpeg-cvslog/2011-December/044542.html).
